### PR TITLE
Don't log requests to stdout

### DIFF
--- a/lib/lemur.rb
+++ b/lib/lemur.rb
@@ -94,7 +94,7 @@ module Lemur
     def init_faraday(faraday_options)
       Faraday.new(faraday_options) do |faraday|
             faraday.request  :url_encoded 
-            faraday.response :logger
+            # faraday.response :logger
             faraday.adapter  Faraday.default_adapter
       end
     end


### PR DESCRIPTION
If you use VCR+Rspec to test odnoklassniki integration, logging requests to stdout results in a lot of logs you don't really need in your console when running rspec. 

I don't think you really need the line in the gem since if anyone needs to debug stuff inside faraday response, they can just plug the logger back in locally. 

